### PR TITLE
Use types as context keys

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -2,7 +2,11 @@ package rx
 
 import (
 	"math/rand"
+	"net/netip"
+	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func BenchmarkContextValues(b *testing.B) {
@@ -28,29 +32,48 @@ func BenchmarkContextValues(b *testing.B) {
 	// simulation note: pattern acces to values is usually skewed towards recent values
 	// to reproduce this, we use the order in switch, making sure that, statistically, key5 is modified twice each time key4 is modified, and so on…
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
+		ctx := Context{vx: &vctx{kv: make(map[reflect.Type]any)}}
 
-		orderkeys := rand.Perm(6)
-		ctx := Context{vx: &vctx{kv: make(map[ContextKey]any)}}
-
-		for i := 0; i < 30_000; i++ {
+		for range 30_000 {
 			rnd := rand.Uint32()
 			va := values[rnd%16]
 
 			switch {
 			case rnd&(1<<key5) > 0:
-				ctx = WithValue(ctx, ContextKey(key5+uint32(orderkeys[i%6])), va)
+				ctx = WithValue(ctx, va)
 			case rnd&(1<<key4) > 0:
-				ctx = WithValue(ctx, ContextKey(key4+uint32(orderkeys[i%6])), va)
+				ctx = WithValue(ctx, va)
 			case rnd&(1<<key3) > 0:
-				ctx = WithValue(ctx, ContextKey(key3+uint32(orderkeys[i%6])), va)
+				ctx = WithValue(ctx, va)
 			case rnd&(1<<key2) > 0:
-				ctx = WithValue(ctx, ContextKey(key2+uint32(orderkeys[i%6])), va)
+				ctx = WithValue(ctx, va)
 			case rnd&key1 > 0:
-				ctx = WithValue(ctx, ContextKey(key1+uint32(orderkeys[i%6])), va)
+				ctx = WithValue(ctx, va)
 			}
 
 			b.ReportMetric(float64(len(ctx.vx.kv)), "valuelength")
 		}
+	}
+}
+
+func TestMutator(t *testing.T) {
+	var ctx Context
+
+	type User struct{ name string }
+	type Endpoint int
+	type Dst netip.Addr
+
+	ctx = WithValues(ctx, User{name: "Doe"}, Endpoint(10))
+
+	Mutate(
+		func(u *User) { u.name = "Bond" },
+		func(e *Endpoint) { *e = 10 },
+		func(d *Dst) { *d = Dst(netip.MustParseAddr("192.0.2.10")) },
+	)(ctx)
+
+	want := User{name: "Bond"}
+	if gu := ValueOf[User](ctx); gu != want {
+		t.Errorf("different user %s", cmp.Diff(want, gu))
 	}
 }

--- a/engine.go
+++ b/engine.go
@@ -3,6 +3,7 @@ package rx
 import (
 	"log/slog"
 	"math/rand"
+	"reflect"
 )
 
 // should be enabled by default, but currently need fix in drag&drop (since this would destroy the persistent entities)
@@ -49,9 +50,9 @@ func New(root Widget, ctx ...any) *Engine {
 		Root:       root,
 		genHandler: newLogHandler(),
 	}
-	ng.g0 = &vctx{kv: make(map[ContextKey]any)}
-	for i := 0; i < len(ctx); i += 2 {
-		ng.g0.kv[ctx[i].(ContextKey)] = ctx[i+1]
+	ng.g0 = &vctx{kv: make(map[reflect.Type]any)}
+	for i := range ctx {
+		ng.g0.kv[reflect.TypeOf(ctx[i])] = ctx[i]
 	}
 	ng.logger = slog.New(ng.genHandler)
 

--- a/render.go
+++ b/render.go
@@ -46,6 +46,12 @@ func (n *Node) OnIntent(evt IntentType, h Action) *Node {
 	n.hdl[evt] = h
 	return n
 }
+
+// React is a executes state mutators on an event
+func (n *Node) React(evt IntentType, mutators ...any) *Node {
+	return n.OnIntent(evt, Mutate(mutators...))
+}
+
 func (n *Node) Focus(ctx Context) *Node { n.Focused = true; return n.GiveKey(ctx) }
 
 // Set ARIA role, using the "role" property


### PR DESCRIPTION
Trying to reduce the boilerplate by using types as keys for context values.
An example of mutator (which can be used in `OnIntent`) is available as a test.

The performance impact of reflection are negligible:
```
goos: linux
goarch: amd64
pkg: github.com/TroutSoftware/rx
cpu: 12th Gen Intel(R) Core(TM) i7-12700
                 │ /tmp/before │             /tmp/after             │
                 │   sec/op    │   sec/op     vs base               │
ContextValues-20   1.433m ± 2%   1.518m ± 0%  +5.90% (p=0.000 n=10)
```